### PR TITLE
ci: workflow and release process improvements

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,7 +5,8 @@ changelog_update = false
 
 [[package]]
 name = "krata"
-git_tag_name = "v${version}"
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"
 git_tag_enable = true
 git_release_enable = true
 changelog_update = true
@@ -16,5 +17,25 @@ changelog_include = [
     "krata-guest",
     "krata-network",
     "krata-runtime",
-    "krata-oci"
+    "krata-oci",
 ]
+
+[[package]]
+name = "krata-xencall"
+semver_check = false
+
+[[package]]
+name = "krata-xenclient"
+semver_check = false
+
+[[package]]
+name = "krata-xenevtchn"
+semver_check = false
+
+[[package]]
+name = "krata-xengnt"
+semver_check = false
+
+[[package]]
+name = "krata-xenstore"
+semver_check = false


### PR DESCRIPTION
- fix release and tag names so that it is v{{ version }}, which will get rid of the problem with v${version} being created.
- don't semver check lower-level crates, since those are not actually public API