### PR TITLE
fix: service files should have kratanet depend on kratad

### DIFF
--- a/resources/openrc/kratad
+++ b/resources/openrc/kratad
@@ -6,7 +6,6 @@ output_log="/var/log/kratad.log"
 error_log="/var/log/kratad.err"
 
 depend() {
-  use xenconsoled
   use xenstored
 }
 

--- a/resources/openrc/kratanet
+++ b/resources/openrc/kratanet
@@ -6,7 +6,7 @@ output_log="/var/log/kratanet.log"
 error_log="/var/log/kratanet.err"
 
 depend() {
-  use xenstored
+  use kratad
 }
 
 export RUST_LOG=info

--- a/resources/systemd/kratanet.service
+++ b/resources/systemd/kratanet.service
@@ -2,6 +2,8 @@
 Description=Krata Networking Daemon
 
 [Service]
+Wants=kratad.service
+After=kratad.service
 Restart=on-failure
 Type=simple
 ExecStart=/usr/libexec/kratanet


### PR DESCRIPTION
the service files don't make kratanet depend on kratad, which is fine normally since kratanet will restart when kratad isn't available, but it is probably better to declare the dependency.

in addition, we also remove the dependency on xenconsoled in OpenRC, since we don't depend on that daemon anymore.