### PR TITLE
fix: release pr trigger problem

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,6 +18,11 @@ jobs:
     name: release-plz
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: "${{ secrets.EDERA_CULTIVATION_APP_ID }}"
+          private-key: "${{ secrets.EDERA_CULTIVATION_APP_PRIVATE_KEY }}"
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -27,5 +32,5 @@ jobs:
       - name: release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           CARGO_REGISTRY_TOKEN: "${{ secrets.KRATA_RELEASE_CARGO_TOKEN }}"


### PR DESCRIPTION
release PRs aren't running status checks because github-actions issued GITHUB_TOKENs mask all new events, in order to prevent loops. We don't care about loops, because the PR merge prevents the loop for happening.