### PR TITLE
chore: release workflow fixes to improve utilization and fix checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,11 @@
 name: check
-on: [push, pull_request, merge_group]
+on:
+  pull_request:
+    branches:
+    - main
+  merge_group:
+    branches:
+    - main
 jobs:
   fmt:
     name: fmt

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,5 +1,11 @@
 name: client
-on: [push, pull_request, merge_group]
+on:
+  pull_request:
+    branches:
+    - main
+  merge_group:
+    branches:
+    - main
 jobs:
   build:
     strategy:

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -1,15 +1,14 @@
 name: kernel
 on:
-  push:
-    paths:
-    - "kernel/**"
-    - "hack/ci/**"
   pull_request:
+    branches:
+    - main
     paths:
     - "kernel/**"
     - "hack/ci/**"
   merge_group:
-
+    branches:
+    - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -1,16 +1,15 @@
 name: os
 on:
-  push:
-    paths:
-    - "os/**"
-    - "hack/os/**"
-    - "hack/ci/**"
   pull_request:
+    branches:
+    - main
     paths:
     - "os/**"
     - "hack/os/**"
     - "hack/ci/**"
   merge_group:
+    branches:
+    - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          token: "${{ steps.generate-token.outputs.token }}"
       - uses: dtolnay/rust-toolchain@stable
       - run: ./hack/ci/install-linux-deps.sh
       - name: release-plz

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,18 +1,13 @@
 name: release-plz
-
 permissions:
   pull-requests: write
   contents: write
-
 on:
   push:
     branches:
     - main
-
 concurrency:
   group: "${{ github.workflow }}"
-  cancel-in-progress: true
-
 jobs:
   release-plz:
     name: release-plz

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,5 +1,11 @@
 name: server
-on: [push, pull_request, merge_group]
+on:
+  pull_request:
+    branches:
+    - main
+  merge_group:
+    branches:
+    - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- use the cultivation bot to push release changes, so that workflows will run when a force-push is used and the PR is already created.
- check/lint workflows should run on merge queue and on pull requests, and no more than that.
- nightly build is still responsible for doing a full main rebuild every night.