### PR TITLE
debug: common: run programs in a way that is compatible with alpine doas-sudo-shim

### DIFF
--- a/hack/debug/common.sh
+++ b/hack/debug/common.sh
@@ -28,5 +28,5 @@ build_and_run() {
   fi
   RUST_TARGET="$(./hack/build/target.sh)"
   ./hack/build/cargo.sh build ${CARGO_BUILD_FLAGS} --bin "${EXE_TARGET}"
-  exec sudo RUST_LOG="${RUST_LOG}" "target/${RUST_TARGET}/debug/${EXE_TARGET}" "${@}"
+  exec sudo sh -c "RUST_LOG='${RUST_LOG}' 'target/${RUST_TARGET}/debug/${EXE_TARGET}' $*"
 }


### PR DESCRIPTION
doas sudo shim (as used by Alpine) does not support passing through environment variables in the same way that sudo does, therefore use `sh -c` instead.