### PR TITLE
build: use LTO for release builds and strip guestinit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,3 +119,4 @@ features = ["v4"]
 
 [profile.release]
 lto = "fat"
+strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,6 @@ features = ["tls"]
 [workspace.dependencies.uuid]
 version = "1.6.1"
 features = ["v4"]
+
+[profile.release]
+lto = "fat"

--- a/hack/initrd/build.sh
+++ b/hack/initrd/build.sh
@@ -14,6 +14,7 @@ export RUSTFLAGS="-Ctarget-feature=+crt-static"
 
 ./hack/build/cargo.sh build "${@}" --release --bin krataguest
 INITRD_DIR="$(mktemp -d /tmp/krata-initrd.XXXXXXXXXXXXX)"
+strip "target/${RUST_TARGET}/release/krataguest"
 cp "target/${RUST_TARGET}/release/krataguest" "${INITRD_DIR}/init"
 chmod +x "${INITRD_DIR}/init"
 cd "${INITRD_DIR}"

--- a/hack/initrd/build.sh
+++ b/hack/initrd/build.sh
@@ -14,7 +14,6 @@ export RUSTFLAGS="-Ctarget-feature=+crt-static"
 
 ./hack/build/cargo.sh build "${@}" --release --bin krataguest
 INITRD_DIR="$(mktemp -d /tmp/krata-initrd.XXXXXXXXXXXXX)"
-strip "target/${RUST_TARGET}/release/krataguest"
 cp "target/${RUST_TARGET}/release/krataguest" "${INITRD_DIR}/init"
 chmod +x "${INITRD_DIR}/init"
 cd "${INITRD_DIR}"


### PR DESCRIPTION
before:

```
-rwxr-xr-x  1 kaniini kaniini 7.5M Apr 13 01:28 init
```

after:

```
-rwxr-xr-x 2 kaniini kaniini 4.5M Apr 13 01:44 init
```

or, in other words, a ~40% reduction in guestinit!