### PR TITLE
feat: idm snooping

### DIFF
--- a/crates/ctl/src/cli/idm_snoop.rs
+++ b/crates/ctl/src/cli/idm_snoop.rs
@@ -1,0 +1,74 @@
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use krata::{
+    events::EventStream,
+    v1::control::{control_service_client::ControlServiceClient, SnoopIdmReply, SnoopIdmRequest},
+};
+
+use tokio_stream::StreamExt;
+use tonic::transport::Channel;
+
+use crate::format::{kv2line, proto2dynamic, proto2kv};
+
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+enum IdmSnoopFormat {
+    Simple,
+    Jsonl,
+    KeyValue,
+}
+
+#[derive(Parser)]
+#[command(about = "Snoop on the IDM bus")]
+pub struct IdmSnoopCommand {
+    #[arg(short, long, default_value = "simple", help = "Output format")]
+    format: IdmSnoopFormat,
+}
+
+impl IdmSnoopCommand {
+    pub async fn run(
+        self,
+        mut client: ControlServiceClient<Channel>,
+        _events: EventStream,
+    ) -> Result<()> {
+        let mut stream = client.snoop_idm(SnoopIdmRequest {}).await?.into_inner();
+
+        while let Some(reply) = stream.next().await {
+            let reply = reply?;
+            match self.format {
+                IdmSnoopFormat::Simple => {
+                    self.print_simple(reply)?;
+                }
+
+                IdmSnoopFormat::Jsonl => {
+                    let value = serde_json::to_value(proto2dynamic(reply)?)?;
+                    let encoded = serde_json::to_string(&value)?;
+                    println!("{}", encoded.trim());
+                }
+
+                IdmSnoopFormat::KeyValue => {
+                    self.print_key_value(reply)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_simple(&self, reply: SnoopIdmReply) -> Result<()> {
+        let from = reply.from;
+        let to = reply.to;
+        let Some(packet) = reply.packet else {
+            return Ok(());
+        };
+        let value = serde_json::to_value(proto2dynamic(packet)?)?;
+        let encoded = serde_json::to_string(&value)?;
+        println!("({} -> {}) {}", from, to, encoded);
+        Ok(())
+    }
+
+    fn print_key_value(&self, reply: SnoopIdmReply) -> Result<()> {
+        let kvs = proto2kv(reply)?;
+        println!("{}", kv2line(kvs));
+        Ok(())
+    }
+}

--- a/crates/ctl/src/cli/mod.rs
+++ b/crates/ctl/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod attach;
 pub mod destroy;
+pub mod idm_snoop;
 pub mod launch;
 pub mod list;
 pub mod logs;
@@ -17,8 +18,9 @@ use krata::{
 use tonic::{transport::Channel, Request};
 
 use self::{
-    attach::AttachCommand, destroy::DestroyCommand, launch::LauchCommand, list::ListCommand,
-    logs::LogsCommand, metrics::MetricsCommand, resolve::ResolveCommand, watch::WatchCommand,
+    attach::AttachCommand, destroy::DestroyCommand, idm_snoop::IdmSnoopCommand,
+    launch::LauchCommand, list::ListCommand, logs::LogsCommand, metrics::MetricsCommand,
+    resolve::ResolveCommand, watch::WatchCommand,
 };
 
 #[derive(Parser)]
@@ -49,6 +51,7 @@ pub enum Commands {
     Watch(WatchCommand),
     Resolve(ResolveCommand),
     Metrics(MetricsCommand),
+    IdmSnoop(IdmSnoopCommand),
 }
 
 impl ControlCommand {
@@ -87,6 +90,10 @@ impl ControlCommand {
 
             Commands::Metrics(metrics) => {
                 metrics.run(client, events).await?;
+            }
+
+            Commands::IdmSnoop(snoop) => {
+                snoop.run(client, events).await?;
             }
         }
         Ok(())

--- a/crates/krata/build.rs
+++ b/crates/krata/build.rs
@@ -6,18 +6,12 @@ fn main() -> Result<()> {
         .descriptor_pool("crate::DESCRIPTOR_POOL")
         .configure(
             &mut config,
-            &[
-                "proto/krata/v1/control.proto",
-                "proto/krata/internal/idm.proto",
-            ],
+            &["proto/krata/v1/control.proto", "proto/krata/bus/idm.proto"],
             &["proto/"],
         )?;
     tonic_build::configure().compile_with_config(
         config,
-        &[
-            "proto/krata/v1/control.proto",
-            "proto/krata/internal/idm.proto",
-        ],
+        &["proto/krata/v1/control.proto", "proto/krata/bus/idm.proto"],
         &["proto/"],
     )?;
     Ok(())

--- a/crates/krata/proto/krata/bus/idm.proto
+++ b/crates/krata/proto/krata/bus/idm.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-package krata.internal.idm;
+package krata.bus.idm;
 
 option java_multiple_files = true;
-option java_package = "dev.krata.proto.internal.idm";
+option java_package = "dev.krata.proto.bus.idm";
 option java_outer_classname = "IdmProto";
 
 import "google/protobuf/struct.proto";

--- a/crates/krata/proto/krata/v1/control.proto
+++ b/crates/krata/proto/krata/v1/control.proto
@@ -6,6 +6,7 @@ option java_multiple_files = true;
 option java_package = "dev.krata.proto.v1.control";
 option java_outer_classname = "ControlProto";
 
+import "krata/bus/idm.proto";
 import "krata/v1/common.proto";
 
 service ControlService {
@@ -17,6 +18,7 @@ service ControlService {
     rpc WatchEvents(WatchEventsRequest) returns (stream WatchEventsReply);
 
     rpc ReadGuestMetrics(ReadGuestMetricsRequest) returns (ReadGuestMetricsReply);
+    rpc SnoopIdm(SnoopIdmRequest) returns (stream SnoopIdmReply);
 }
 
 message CreateGuestRequest {
@@ -109,4 +111,12 @@ message ReadGuestMetricsRequest {
 
 message ReadGuestMetricsReply {
     krata.v1.common.GuestMetricNode root = 1;
+}
+
+message SnoopIdmRequest {}
+
+message SnoopIdmReply {
+    uint32 from = 1;
+    uint32 to = 2;
+    krata.bus.idm.IdmPacket packet = 3;
 }

--- a/crates/krata/src/bus/idm.rs
+++ b/crates/krata/src/bus/idm.rs
@@ -1,6 +1,6 @@
 use prost_types::{ListValue, Value};
 
-include!(concat!(env!("OUT_DIR"), "/krata.internal.idm.rs"));
+include!(concat!(env!("OUT_DIR"), "/krata.bus.idm.rs"));
 
 pub trait AsIdmMetricValue {
     fn as_metric_value(&self) -> Value;

--- a/crates/krata/src/bus/mod.rs
+++ b/crates/krata/src/bus/mod.rs
@@ -1,0 +1,1 @@
+pub mod idm;

--- a/crates/krata/src/idm/client.rs
+++ b/crates/krata/src/idm/client.rs
@@ -8,10 +8,9 @@ use std::{
     time::Duration,
 };
 
-use crate::idm::protocol::idm_packet::Content;
-
 use super::protocol::{
-    idm_request::Request, idm_response::Response, IdmEvent, IdmPacket, IdmRequest, IdmResponse,
+    idm_packet::Content, idm_request::Request, idm_response::Response, IdmEvent, IdmPacket,
+    IdmRequest, IdmResponse,
 };
 use anyhow::{anyhow, Result};
 use log::{debug, error};

--- a/crates/krata/src/idm/mod.rs
+++ b/crates/krata/src/idm/mod.rs
@@ -1,3 +1,3 @@
 #[cfg(unix)]
 pub mod client;
-pub mod protocol;
+pub use crate::bus::idm as protocol;

--- a/crates/krata/src/lib.rs
+++ b/crates/krata/src/lib.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use prost_reflect::DescriptorPool;
 
+pub mod bus;
 pub mod v1;
 
 pub mod client;


### PR DESCRIPTION
Implement IDM snooping, a new feature that lets you snoop on messages between guests and the host. The feature exposes the IDM packets send and receives to the API, allowing kratactl to now listen for messages and feed them to a user for debugging purposes.

This PR fixes #67 