### PR TITLE
fix: oci cache store should fallback to copy when rename won't work

### DIFF
--- a/crates/oci/src/packer/cache.rs
+++ b/crates/oci/src/packer/cache.rs
@@ -123,7 +123,10 @@ impl OciPackerCache {
         fs_path.push(format!("{}.{}", packed.digest, packed.format.extension()));
         manifest_path.push(format!("{}.manifest.json", packed.digest));
         config_path.push(format!("{}.config.json", packed.digest));
-        fs::rename(&packed.path, &fs_path).await?;
+        if fs::rename(&packed.path, &fs_path).await.is_err() {
+            fs::copy(&packed.path, &fs_path).await?;
+            fs::remove_file(&packed.path).await?;
+        }
         fs::write(&config_path, packed.config.raw()).await?;
         fs::write(&manifest_path, packed.manifest.raw()).await?;
         manifests.retain(|item| {


### PR DESCRIPTION
fs::rename won't work for cross-device moves (oops)

now, we attempt rename, if that fails then we fallback to a copy and remove.
rename is still used because it prevents us from paying the cost of a copy if it's possible to avoid.