### PR TITLE
feat: implement kernel / initrd oci image support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "krata",
  "krata-oci",
  "krata-runtime",
+ "krata-tokio-tar",
  "log",
  "prost",
  "redb",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -27,6 +27,7 @@ scopeguard = { workspace = true }
 signal-hook = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+krata-tokio-tar = { workspace = true }
 tonic = { workspace = true, features = ["tls"] }
 uuid = { workspace = true }
 

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -378,7 +378,7 @@ impl ControlService for DaemonControlService {
                             format: match packed.format {
                                 OciPackedFormat::Squashfs => OciImageFormat::Squashfs.into(),
                                 OciPackedFormat::Erofs => OciImageFormat::Erofs.into(),
-                                _ => OciImageFormat::Unknown.into(),
+                                OciPackedFormat::Tar => OciImageFormat::Tar.into(),
                             },
                         };
                         yield reply;

--- a/crates/daemon/src/reconcile/guest/start.rs
+++ b/crates/daemon/src/reconcile/guest/start.rs
@@ -1,0 +1,182 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use futures::StreamExt;
+use krata::launchcfg::LaunchPackedFormat;
+use krata::v1::common::GuestOciImageSpec;
+use krata::v1::common::{guest_image_spec::Image, Guest, GuestState, GuestStatus, OciImageFormat};
+use krataoci::packer::{service::OciPackerService, OciPackedFormat};
+use kratart::{launch::GuestLaunchRequest, Runtime};
+use log::info;
+
+use tokio::fs::{self, File};
+use tokio::io::AsyncReadExt;
+use tokio_tar::Archive;
+use uuid::Uuid;
+
+use crate::{
+    glt::GuestLookupTable,
+    reconcile::guest::{guestinfo_to_networkstate, GuestReconcilerResult},
+};
+
+// if a kernel is >= 100MB, that's kinda scary.
+const OCI_SPEC_TAR_FILE_MAX_SIZE: usize = 100 * 1024 * 1024;
+
+pub struct GuestStarter<'a> {
+    pub kernel_path: &'a Path,
+    pub initrd_path: &'a Path,
+    pub packer: &'a OciPackerService,
+    pub glt: &'a GuestLookupTable,
+    pub runtime: &'a Runtime,
+}
+
+impl GuestStarter<'_> {
+    pub async fn oci_spec_tar_read_file(
+        &self,
+        file: &Path,
+        oci: &GuestOciImageSpec,
+    ) -> Result<Vec<u8>> {
+        if oci.format() != OciImageFormat::Tar {
+            return Err(anyhow!(
+                "oci image spec for {} is required to be in tar format",
+                oci.digest
+            ));
+        }
+
+        let image = self
+            .packer
+            .recall(&oci.digest, OciPackedFormat::Tar)
+            .await?;
+
+        let Some(image) = image else {
+            return Err(anyhow!("image {} was not found in tar format", oci.digest));
+        };
+
+        let mut archive = Archive::new(File::open(&image.path).await?);
+        let mut entries = archive.entries()?;
+        while let Some(entry) = entries.next().await {
+            let mut entry = entry?;
+            let path = entry.path()?;
+            if entry.header().size()? as usize > OCI_SPEC_TAR_FILE_MAX_SIZE {
+                return Err(anyhow!(
+                    "file {} in image {} is larger than the size limit",
+                    file.to_string_lossy(),
+                    oci.digest
+                ));
+            }
+            if path == file {
+                let mut buffer = Vec::new();
+                entry.read_to_end(&mut buffer).await?;
+                return Ok(buffer);
+            }
+        }
+        Err(anyhow!(
+            "unable to find file {} in image {}",
+            file.to_string_lossy(),
+            oci.digest
+        ))
+    }
+
+    pub async fn start(&self, uuid: Uuid, guest: &mut Guest) -> Result<GuestReconcilerResult> {
+        let Some(ref spec) = guest.spec else {
+            return Err(anyhow!("guest spec not specified"));
+        };
+
+        let Some(ref image) = spec.image else {
+            return Err(anyhow!("image spec not provided"));
+        };
+        let oci = match image.image {
+            Some(Image::Oci(ref oci)) => oci,
+            None => {
+                return Err(anyhow!("oci spec not specified"));
+            }
+        };
+        let task = spec.task.as_ref().cloned().unwrap_or_default();
+
+        let image = self
+            .packer
+            .recall(
+                &oci.digest,
+                match oci.format() {
+                    OciImageFormat::Unknown => OciPackedFormat::Squashfs,
+                    OciImageFormat::Squashfs => OciPackedFormat::Squashfs,
+                    OciImageFormat::Erofs => OciPackedFormat::Erofs,
+                    OciImageFormat::Tar => {
+                        return Err(anyhow!("tar image format is not supported for guests"));
+                    }
+                },
+            )
+            .await?;
+
+        let Some(image) = image else {
+            return Err(anyhow!(
+                "image {} in the requested format did not exist",
+                oci.digest
+            ));
+        };
+
+        let kernel = if let Some(ref spec) = spec.kernel {
+            let Some(Image::Oci(ref oci)) = spec.image else {
+                return Err(anyhow!("kernel image spec must be an oci image"));
+            };
+            self.oci_spec_tar_read_file(&PathBuf::from("kernel/image"), oci)
+                .await?
+        } else {
+            fs::read(&self.kernel_path).await?
+        };
+        let initrd = if let Some(ref spec) = spec.initrd {
+            let Some(Image::Oci(ref oci)) = spec.image else {
+                return Err(anyhow!("initrd image spec must be an oci image"));
+            };
+            self.oci_spec_tar_read_file(&PathBuf::from("krata/initrd"), oci)
+                .await?
+        } else {
+            fs::read(&self.initrd_path).await?
+        };
+
+        let info = self
+            .runtime
+            .launch(GuestLaunchRequest {
+                format: LaunchPackedFormat::Squashfs,
+                uuid: Some(uuid),
+                name: if spec.name.is_empty() {
+                    None
+                } else {
+                    Some(spec.name.clone())
+                },
+                image,
+                kernel,
+                initrd,
+                vcpus: spec.vcpus,
+                mem: spec.mem,
+                env: task
+                    .environment
+                    .iter()
+                    .map(|x| (x.key.clone(), x.value.clone()))
+                    .collect::<HashMap<_, _>>(),
+                run: empty_vec_optional(task.command.clone()),
+                debug: false,
+            })
+            .await?;
+        self.glt.associate(uuid, info.domid).await;
+        info!("started guest {}", uuid);
+        guest.state = Some(GuestState {
+            status: GuestStatus::Started.into(),
+            network: Some(guestinfo_to_networkstate(&info)),
+            exit_info: None,
+            error_info: None,
+            host: self.glt.host_uuid().to_string(),
+            domid: info.domid,
+        });
+        Ok(GuestReconcilerResult::Changed { rerun: false })
+    }
+}
+
+fn empty_vec_optional<T>(value: Vec<T>) -> Option<Vec<T>> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}

--- a/crates/krata/proto/krata/v1/common.proto
+++ b/crates/krata/proto/krata/v1/common.proto
@@ -17,10 +17,14 @@ message Guest {
 message GuestSpec {
     string name = 1;
     GuestImageSpec image = 2;
-    uint32 vcpus = 3;
-    uint64 mem = 4;
-    GuestTaskSpec task = 5;
-    repeated GuestSpecAnnotation annotations = 6;
+    // If not specified, defaults to the daemon default kernel.
+    GuestImageSpec kernel = 3;
+    // If not specified, defaults to the daemon default initrd.
+    GuestImageSpec initrd = 4;
+    uint32 vcpus = 5;
+    uint64 mem = 6;
+    GuestTaskSpec task = 7;
+    repeated GuestSpecAnnotation annotations = 8;
 }
 
 message GuestImageSpec {

--- a/crates/oci/src/fetch.rs
+++ b/crates/oci/src/fetch.rs
@@ -217,6 +217,13 @@ impl OciImageFetcher {
                         continue;
                     }
                 }
+
+                if let Some(ref digest) = image.digest {
+                    if digest != manifest.digest() {
+                        continue;
+                    }
+                }
+
                 found = Some(manifest);
                 break;
             }
@@ -240,7 +247,7 @@ impl OciImageFetcher {
 
         let mut client = OciRegistryClient::new(image.registry_url()?, self.platform.clone())?;
         let (manifest, descriptor, digest) = client
-            .get_manifest_with_digest(&image.name, &image.reference)
+            .get_manifest_with_digest(&image.name, image.reference.as_ref(), image.digest.as_ref())
             .await?;
         let descriptor = descriptor.unwrap_or_else(|| {
             DescriptorBuilder::default()

--- a/crates/oci/src/name.rs
+++ b/crates/oci/src/name.rs
@@ -2,33 +2,39 @@ use anyhow::Result;
 use std::fmt;
 use url::Url;
 
-const DOCKER_HUB_MIRROR: &str = "mirror.gcr.io";
-const DEFAULT_IMAGE_TAG: &str = "latest";
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImageName {
     pub hostname: String,
     pub port: Option<u16>,
     pub name: String,
-    pub reference: String,
+    pub reference: Option<String>,
+    pub digest: Option<String>,
 }
 
 impl fmt::Display for ImageName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if DOCKER_HUB_MIRROR == self.hostname && self.port.is_none() {
+        let mut suffix = String::new();
+
+        if let Some(ref reference) = self.reference {
+            suffix.push(':');
+            suffix.push_str(reference);
+        }
+
+        if let Some(ref digest) = self.digest {
+            suffix.push('@');
+            suffix.push_str(digest);
+        }
+
+        if ImageName::DOCKER_HUB_MIRROR == self.hostname && self.port.is_none() {
             if self.name.starts_with("library/") {
-                write!(f, "{}:{}", &self.name[8..], self.reference)
+                write!(f, "{}{}", &self.name[8..], suffix)
             } else {
-                write!(f, "{}:{}", self.name, self.reference)
+                write!(f, "{}{}", self.name, suffix)
             }
         } else if let Some(port) = self.port {
-            write!(
-                f,
-                "{}:{}/{}:{}",
-                self.hostname, port, self.name, self.reference
-            )
+            write!(f, "{}:{}/{}{}", self.hostname, port, self.name, suffix)
         } else {
-            write!(f, "{}/{}:{}", self.hostname, self.name, self.reference)
+            write!(f, "{}/{}{}", self.hostname, self.name, suffix)
         }
     }
 }
@@ -41,13 +47,21 @@ impl Default for ImageName {
 }
 
 impl ImageName {
+    pub const DOCKER_HUB_MIRROR: &'static str = "registry.docker.io";
+    pub const DEFAULT_IMAGE_TAG: &'static str = "latest";
+
     pub fn parse(name: &str) -> Result<Self> {
         let full_name = name.to_string();
         let name = full_name.clone();
         let (mut hostname, mut name) = name
             .split_once('/')
             .map(|x| (x.0.to_string(), x.1.to_string()))
-            .unwrap_or_else(|| (DOCKER_HUB_MIRROR.to_string(), format!("library/{}", name)));
+            .unwrap_or_else(|| {
+                (
+                    ImageName::DOCKER_HUB_MIRROR.to_string(),
+                    format!("library/{}", name),
+                )
+            });
 
         // heuristic to find any docker hub image formats
         // that may be in the hostname format. for example:
@@ -55,7 +69,7 @@ impl ImageName {
         // and neither will abc/hello/xyz:latest
         if !hostname.contains('.') && full_name.chars().filter(|x| *x == '/').count() == 1 {
             name = format!("{}/{}", hostname, name);
-            hostname = DOCKER_HUB_MIRROR.to_string();
+            hostname = ImageName::DOCKER_HUB_MIRROR.to_string();
         }
 
         let (hostname, port) = if let Some((hostname, port)) = hostname
@@ -66,15 +80,54 @@ impl ImageName {
         } else {
             (hostname, None)
         };
-        let (name, reference) = name
-            .split_once(':')
-            .map(|x| (x.0.to_string(), x.1.to_string()))
-            .unwrap_or((name.to_string(), DEFAULT_IMAGE_TAG.to_string()));
+
+        let name_has_digest = if name.contains('@') {
+            let digest_start = name.chars().position(|c| c == '@');
+            let ref_start = name.chars().position(|c| c == ':');
+            if let (Some(digest_start), Some(ref_start)) = (digest_start, ref_start) {
+                digest_start < ref_start
+            } else {
+                true
+            }
+        } else {
+            false
+        };
+
+        let (name, digest) = if name_has_digest {
+            name.split_once('@')
+                .map(|(name, digest)| (name.to_string(), Some(digest.to_string())))
+                .unwrap_or_else(|| (name, None))
+        } else {
+            (name, None)
+        };
+
+        let (name, reference) = if name.contains(':') {
+            name.split_once(':')
+                .map(|(name, reference)| (name.to_string(), Some(reference.to_string())))
+                .unwrap_or((name, None))
+        } else {
+            (name, None)
+        };
+
+        let (reference, digest) = if let Some(reference) = reference {
+            if let Some(digest) = digest {
+                (Some(reference), Some(digest))
+            } else {
+                reference
+                    .split_once('@')
+                    .map(|(reff, digest)| (Some(reff.to_string()), Some(digest.to_string())))
+                    .unwrap_or_else(|| (Some(reference), None))
+            }
+        } else {
+            (None, digest)
+        };
+
         Ok(ImageName {
             hostname,
             port,
             name,
             reference,
+            digest,
         })
     }
 

--- a/crates/oci/src/packer/cache.rs
+++ b/crates/oci/src/packer/cache.rs
@@ -159,7 +159,9 @@ impl OciPackerCache {
         let image_name = packed.name.to_string();
         annotations.insert(ANNOTATION_IMAGE_NAME.to_string(), image_name);
         let image_ref = packed.name.reference.clone();
-        annotations.insert(ANNOTATION_REF_NAME.to_string(), image_ref);
+        if let Some(image_ref) = image_ref {
+            annotations.insert(ANNOTATION_REF_NAME.to_string(), image_ref);
+        }
         descriptor.set_annotations(Some(annotations));
         manifests.push(descriptor.clone());
         index.set_manifests(manifests);

--- a/crates/oci/src/packer/service.rs
+++ b/crates/oci/src/packer/service.rs
@@ -61,6 +61,10 @@ impl OciPackerService {
         digest: &str,
         format: OciPackedFormat,
     ) -> Result<Option<OciPackedImage>> {
+        if digest.contains('/') || digest.contains('\\') || digest.contains("..") {
+            return Ok(None);
+        }
+
         self.cache
             .recall(ImageName::parse("cached:latest")?, digest, format)
             .await

--- a/crates/runtime/src/launch.rs
+++ b/crates/runtime/src/launch.rs
@@ -23,6 +23,8 @@ use super::{GuestInfo, GuestState};
 
 pub struct GuestLaunchRequest {
     pub format: LaunchPackedFormat,
+    pub kernel: Vec<u8>,
+    pub initrd: Vec<u8>,
     pub uuid: Option<Uuid>,
     pub name: Option<String>,
     pub vcpus: u32,
@@ -173,22 +175,22 @@ impl GuestLauncher {
 
         let config = DomainConfig {
             backend_domid: 0,
-            name: &xen_name,
+            name: xen_name,
             max_vcpus: request.vcpus,
             mem_mb: request.mem,
-            kernel_path: &context.kernel,
-            initrd_path: &context.initrd,
-            cmdline: &cmdline,
-            use_console_backend: Some("krata-console"),
+            kernel: request.kernel,
+            initrd: request.initrd,
+            cmdline,
+            use_console_backend: Some("krata-console".to_string()),
             disks: vec![
                 DomainDisk {
-                    vdev: "xvda",
-                    block: &image_squashfs_loop,
+                    vdev: "xvda".to_string(),
+                    block: image_squashfs_loop.clone(),
                     writable: false,
                 },
                 DomainDisk {
-                    vdev: "xvdb",
-                    block: &cfgblk_squashfs_loop,
+                    vdev: "xvdb".to_string(),
+                    block: cfgblk_squashfs_loop.clone(),
                     writable: false,
                 },
             ],
@@ -197,7 +199,7 @@ impl GuestLauncher {
                 initialized: false,
             }],
             vifs: vec![DomainNetworkInterface {
-                mac: &guest_mac_string,
+                mac: guest_mac_string.clone(),
                 mtu: 1500,
                 bridge: None,
                 script: None,

--- a/crates/xen/xenclient/examples/boot.rs
+++ b/crates/xen/xenclient/examples/boot.rs
@@ -1,4 +1,5 @@
 use std::{env, process};
+use tokio::fs;
 use xenclient::error::Result;
 use xenclient::{DomainConfig, XenClient};
 
@@ -16,12 +17,12 @@ async fn main() -> Result<()> {
     let client = XenClient::open(0).await?;
     let config = DomainConfig {
         backend_domid: 0,
-        name: "xenclient-test",
+        name: "xenclient-test".to_string(),
         max_vcpus: 1,
         mem_mb: 512,
-        kernel_path: kernel_image_path.as_str(),
-        initrd_path: initrd_path.as_str(),
-        cmdline: "debug elevator=noop",
+        kernel: fs::read(&kernel_image_path).await?,
+        initrd: fs::read(&initrd_path).await?,
+        cmdline: "debug elevator=noop".to_string(),
         use_console_backend: None,
         disks: vec![],
         channels: vec![],

--- a/crates/xen/xenclient/src/elfloader.rs
+++ b/crates/xen/xenclient/src/elfloader.rs
@@ -107,17 +107,15 @@ impl ElfImageLoader {
         ElfImageLoader::load_xz(file.as_slice())
     }
 
-    pub fn load_file_kernel(path: &str) -> Result<ElfImageLoader> {
-        let file = std::fs::read(path)?;
-
-        for start in find_iter(file.as_slice(), &[0x1f, 0x8b]) {
-            if let Ok(elf) = ElfImageLoader::load_gz(&file[start..]) {
+    pub fn load_file_kernel(data: &[u8]) -> Result<ElfImageLoader> {
+        for start in find_iter(data, &[0x1f, 0x8b]) {
+            if let Ok(elf) = ElfImageLoader::load_gz(&data[start..]) {
                 return Ok(elf);
             }
         }
 
-        for start in find_iter(file.as_slice(), &[0xfd, 0x37, 0x7a, 0x58]) {
-            if let Ok(elf) = ElfImageLoader::load_xz(&file[start..]) {
+        for start in find_iter(data, &[0xfd, 0x37, 0x7a, 0x58]) {
+            if let Ok(elf) = ElfImageLoader::load_xz(&data[start..]) {
                 return Ok(elf);
             }
         }


### PR DESCRIPTION
- kernel images can now be used to specify a kernel by packing an OCI Image with a "kernel/image" file.
- initrd image can now be used to specify an initrd by packing an OCI Image with a "krata/initrd" file.