### PR TITLE
fix(xenclient): use a single transaction for device setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "elf",
  "env_logger",
  "flate2",
+ "indexmap 2.2.6",
  "krata-xencall",
  "krata-xenstore",
  "libc",

--- a/crates/xen/xencall/src/lib.rs
+++ b/crates/xen/xencall/src/lib.rs
@@ -791,7 +791,13 @@ impl XenCall {
             index,
             pirq,
         );
-        let mut physdev = PhysdevMapPirq::default();
+        let mut physdev = PhysdevMapPirq {
+            domid: domid as u16,
+            typ: 0x1,
+            index: index as c_int,
+            pirq: pirq.map(|x| x as c_int).unwrap_or(index as c_int),
+            ..Default::default()
+        };
         physdev.domid = domid as u16;
         physdev.typ = 0x1;
         physdev.index = index as c_int;

--- a/crates/xen/xenclient/Cargo.toml
+++ b/crates/xen/xenclient/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 async-trait = { workspace = true }
 elf = { workspace = true }
 flate2 = { workspace = true }
+indexmap = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 krata-xencall = { path = "../xencall", version = "^0.0.10" }

--- a/crates/xen/xenclient/src/pci.rs
+++ b/crates/xen/xenclient/src/pci.rs
@@ -112,6 +112,13 @@ impl XenPciBackend {
         Ok(resources)
     }
 
+    pub async fn enable_permissive(&self, bdf: &PciBdf) -> Result<()> {
+        let mut path: PathBuf = self.path.clone();
+        path.push("permissive");
+        fs::write(path, bdf.to_string()).await?;
+        Ok(())
+    }
+
     pub async fn has_slot(&self, bdf: &PciBdf) -> Result<bool> {
         let mut slots_path = self.path.clone();
         slots_path.push("slots");
@@ -128,8 +135,9 @@ impl XenPciBackend {
 
     pub async fn reset(&self, bdf: &PciBdf) -> Result<()> {
         let mut path: PathBuf = self.path.clone();
-        path.push("do_flr");
-        fs::write(&path, bdf.to_string()).await?;
+        path.push(bdf.to_string());
+        path.push("reset");
+        let _ = fs::write(path, "1\n").await;
         Ok(())
     }
 }


### PR DESCRIPTION
currently, there are multiple transactions when setting up devices in xenclient, with this, there is a single commit.