### PR TITLE
fix(oci): use mirror.gcr.io as a mirror to docker hub

### DIFF
--- a/crates/oci/src/name.rs
+++ b/crates/oci/src/name.rs
@@ -47,7 +47,7 @@ impl Default for ImageName {
 }
 
 impl ImageName {
-    pub const DOCKER_HUB_MIRROR: &'static str = "registry-1.docker.io";
+    pub const DOCKER_HUB_MIRROR: &'static str = "mirror.gcr.io";
     pub const DEFAULT_IMAGE_TAG: &'static str = "latest";
 
     pub fn parse(name: &str) -> Result<Self> {


### PR DESCRIPTION
docker hub rate limits, and since we don't yet have support for repository secrets (coming soon!) it's safe to just swap.