### PR TITLE
fix(build): use host resolv.conf in os build chroot

### DIFF
--- a/hack/os/build.sh
+++ b/hack/os/build.sh
@@ -99,7 +99,10 @@ sudo mount --make-private "${ROOT_DIR}/sys"
 
 sudo cp "${PWD}/os/internal/stage2.sh" "${ROOT_DIR}/stage2.sh"
 echo "${ROOT_UUID}" | sudo tee "${ROOT_DIR}/root-uuid" > /dev/null
+sudo mv "${ROOT_DIR}/etc/resolv.conf" "${ROOT_DIR}/etc/resolv.conf.orig"
+sudo cp "/etc/resolv.conf" "${ROOT_DIR}/etc/resolv.conf"
 sudo chroot "${ROOT_DIR}" /bin/sh -c "/stage2.sh ${TARGET_ARCH} ${TARGET_ARCH_ALT}"
+sudo mv "${ROOT_DIR}/etc/resolv.conf.orig" "${ROOT_DIR}/etc/resolv.conf"
 sudo rm -f "${ROOT_DIR}/stage2.sh"
 sudo rm -f "${ROOT_DIR}/root-uuid"
 


### PR DESCRIPTION
The resolv.conf that the stage1 os script generates is fine for actual use, but our GitHub workflows now uses the Step Security hardened runner action. This action replaces the nameserver so that all lookups go through that, but because the chroot calls apk add, it needs to contact the internet. On the GitHub workflows, the OS build currently fails since the hardened runner cannot access other nameservers.