### PR TITLE
chore(dependabot): group some dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+    version-updates:
+      dependency-type: "all"
+      applies-to: "version-updates"
 - package-ecosystem: "cargo"
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+    version-updates:
+      dependency-type: "all"
+      applies-to: "version-updates"


### PR DESCRIPTION
We have a need to ensure great security while also ensuring that dependabot does not constantly provide multiple PRs. After all, when something becomes too time consuming it risks not being handled with care. With grouped updates, version bumps will get grouped together, but security updates will still be indvidualized. This makes it safer for us to enable grouped dependency updates.