### PR TITLE
fix(build): kernel fetch should use host target

### DIFF
--- a/hack/kernel/fetch.sh
+++ b/hack/kernel/fetch.sh
@@ -6,6 +6,7 @@ cd "$(dirname "${REAL_SCRIPT}")/../.."
 KRATA_DIR="${PWD}"
 cd "${KRATA_DIR}"
 
+HOST_RUST_TARGET="$(TARGET_ARCH="" TARGET_LIBC="" ./hack/build/target.sh)"
 TARGET_ARCH="$(./hack/build/arch.sh)"
 
 if [ "${1}" != "-u" ] && [ -f "target/kernel/kernel-${TARGET_ARCH}" ]
@@ -14,4 +15,5 @@ then
 fi
 
 export TARGET_ARCH
-exec ./hack/build/cargo.sh run -q --bin build-fetch-kernel ghcr.io/edera-dev/kernels:latest
+TARGET_ARCH="" TARGET_LIBC="" RUST_TARGET="${HOST_RUST_TARGET}" ./hack/build/cargo.sh build -q --bin build-fetch-kernel
+exec "target/${HOST_RUST_TARGET}/debug/build-fetch-kernel" "ghcr.io/edera-dev/kernels:latest"


### PR DESCRIPTION
The kernel fetch script should build use the host target at all times.