### PR TITLE
fix(os): alpine v3.20 requires copying kernel config before grub-mkconfig

### DIFF
--- a/os/internal/stage2.sh
+++ b/os/internal/stage2.sh
@@ -25,6 +25,8 @@ ROOT_UUID="$(cat /root-uuid)"
     echo 'GRUB_SAVEDEFAULT="true"'
 } >> /etc/default/grub
 
+# fix bug in grub detection of xen support
+cp /boot/config-*-lts /boot/config-lts
 grub-mkconfig -o /boot/grub/grub.cfg
 grub-set-default "$(grep ^menuentry /boot/grub/grub.cfg | grep Xen | cut -d \' -f 2 | head -1)"
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
There is currently a bug in the Xen support for Alpine where /boot/config-lts is expected to exist but in Alpine /boot/config-VERSION-lts is the only file available. This change copies the config to /boot/config-lts to fix the build.