### PR TITLE
Initial fluentd support

### DIFF
--- a/crates/daemon/bin/daemon.rs
+++ b/crates/daemon/bin/daemon.rs
@@ -1,15 +1,41 @@
+use std::{
+    net::{SocketAddr, TcpStream},
+    str::FromStr,
+    sync::{atomic::AtomicBool, Arc},
+};
+
 use anyhow::Result;
 use clap::Parser;
-use env_logger::Env;
-use kratad::command::DaemonCommand;
+use env_logger::fmt::Target;
 use log::LevelFilter;
-use std::sync::{atomic::AtomicBool, Arc};
+
+use kratad::command::DaemonCommand;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
-        .filter(Some("backhand::filesystem::writer"), LevelFilter::Warn)
-        .init();
+    let mut builder = env_logger::Builder::new();
+    builder
+        .filter_level(LevelFilter::Trace)
+        .parse_default_env()
+        .filter(Some("backhand::filesystem::writer"), LevelFilter::Warn);
+
+    if let Ok(f_addr) = std::env::var("KRATA_FLUENT_ADDR") {
+        println!("KRATA_FLUENT_ADDR set to {f_addr}");
+        let target = SocketAddr::from_str(f_addr.as_str())?;
+        builder.target(Target::Pipe(Box::new(TcpStream::connect(target)?)));
+    }
+
+    let ev = std::env::vars()
+        .into_iter()
+        .fold(String::new(), |mut acc, (k, v)| {
+            acc.push_str(&format!("{k}={v}\n"));
+            acc
+        });
+
+    std::fs::write("/var/log/krata/ev", ev)?;
+
+    builder.init();
+
     mask_sighup()?;
 
     let command = DaemonCommand::parse();

--- a/crates/daemon/src/event.rs
+++ b/crates/daemon/src/event.rs
@@ -9,7 +9,7 @@ use krata::{
     idm::{internal::event::Event as EventType, internal::Event},
     v1::common::{GuestExitInfo, GuestState, GuestStatus},
 };
-use log::{error, warn};
+use log::{error, info, warn};
 use tokio::{
     select,
     sync::{
@@ -90,6 +90,7 @@ impl DaemonEventGenerator {
         let status = state.status();
         let id = Uuid::from_str(&guest.id)?;
         let domid = state.domid;
+        info!("Guest {} on Zone {} changed - {:?}", id, domid, status);
         match status {
             GuestStatus::Started => {
                 if let Entry::Vacant(e) = self.idms.entry(domid) {

--- a/hack/debug/common.sh
+++ b/hack/debug/common.sh
@@ -28,5 +28,5 @@ build_and_run() {
   fi
   RUST_TARGET="$(./hack/build/target.sh)"
   ./hack/build/cargo.sh build ${CARGO_BUILD_FLAGS} --bin "${EXE_TARGET}"
-  exec sudo sh -c "RUST_LOG='${RUST_LOG}' 'target/${RUST_TARGET}/debug/${EXE_TARGET}' $*"
+  exec sudo -E sh -c "RUST_LOG='${RUST_LOG}' 'target/${RUST_TARGET}/debug/${EXE_TARGET}' $*"
 }


### PR DESCRIPTION
This change adds the ability for the Krata daemon to send log events to fluentd over TCP. This change creates a few pieces of technical debt:
- stdout logging is disabled when pushing to fluentd. This is because env-logger doesn't support parallel sinks.
- only TCP is supported at the moment, and there is no ability for it to reconnect to fluentd should the stream die without restarting the daemon

In addition to addressing the above, this work has highlighted the following future improvements:
- We should be using structured logging
- We should use a log crate that supports parallel sinks
- We need to aggregate logs across components over IDM before exporting
- We need to expose the ability to fine tune the o11y configuration