### PR TITLE
fix(power): ensure that xeon cpus with cpu gaps are not detected as p/e compatible

### DIFF
--- a/crates/daemon/src/event.rs
+++ b/crates/daemon/src/event.rs
@@ -9,7 +9,7 @@ use krata::{
     idm::{internal::event::Event as EventType, internal::Event},
     v1::common::{GuestExitInfo, GuestState, GuestStatus},
 };
-use log::{error, info, warn};
+use log::{error, warn};
 use tokio::{
     select,
     sync::{
@@ -90,7 +90,6 @@ impl DaemonEventGenerator {
         let status = state.status();
         let id = Uuid::from_str(&guest.id)?;
         let domid = state.domid;
-        info!("Guest {} on Zone {} changed - {:?}", id, domid, status);
         match status {
             GuestStatus::Started => {
                 if let Entry::Vacant(e) = self.idms.entry(domid) {

--- a/crates/runtime/src/power.rs
+++ b/crates/runtime/src/power.rs
@@ -47,7 +47,12 @@ fn labelled_topo(input: &[SysctlCputopo]) -> Vec<CpuTopologyInfo> {
         }
 
         if last
-            .map(|last| (item.core - last.core) >= 2)
+            .map(|last| {
+                item.core
+                    .checked_sub(last.core)
+                    .map(|diff| diff >= 3)
+                    .unwrap_or(false)
+            })
             .unwrap_or(false)
         {
             // detect if performance cores seem to be kicking in.


### PR DESCRIPTION
Xeon machines were being mis-detected a P/E compatible, as well as a crash occurring due to overflow during subtraction. This fixes that by checking for gaps of 3 CPU cores, and it now uses checked subtraction to avoid the prior crash.