### PR TITLE
feature(oci): add configuration value for oci seed file

### DIFF
--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -7,7 +7,15 @@ use tokio::fs;
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct DaemonConfig {
     #[serde(default)]
+    pub oci: OciConfig,
+    #[serde(default)]
     pub pci: DaemonPciConfig,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct OciConfig {
+    #[serde(default)]
+    pub seed: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -93,7 +93,8 @@ impl Daemon {
         let kernel_path = detect_guest_path(&store, "kernel")?;
         let addons_path = detect_guest_path(&store, "addons.squashfs")?;
 
-        let packer = OciPackerService::new(None, &image_cache_dir, OciPlatform::current()).await?;
+        let seed = config.oci.seed.clone().map(PathBuf::from);
+        let packer = OciPackerService::new(seed, &image_cache_dir, OciPlatform::current()).await?;
         let runtime = Runtime::new(host_uuid).await?;
         let glt = GuestLookupTable::new(0, host_uuid);
         let guests_db_path = format!("{}/guests.db", store);
@@ -128,7 +129,9 @@ impl Daemon {
         // TODO: Make initial power management policy configurable.
         let power = runtime.power_management_context().await?;
         power.set_smt_policy(true).await?;
-        power.set_scheduler_policy("performance".to_string()).await?;
+        power
+            .set_scheduler_policy("performance".to_string())
+            .await?;
 
         Ok(Self {
             store,


### PR DESCRIPTION
This implements a config option to specify an OCI seed, which is the same file format as `docker image save`. This allows you to import seeded images into krata without touching the network.