### PR TITLE
chore(powermgmt): disable for now as a hackfix

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -127,11 +127,12 @@ impl Daemon {
 
         // TODO: Create a way of abstracting early init tasks in kratad.
         // TODO: Make initial power management policy configurable.
-        let power = runtime.power_management_context().await?;
-        power.set_smt_policy(true).await?;
-        power
-            .set_scheduler_policy("performance".to_string())
-            .await?;
+        // FIXME: Power management hypercalls fail when running as an L1 hypervisor.
+        // let power = runtime.power_management_context().await?;
+        // power.set_smt_policy(true).await?;
+        // power
+        //     .set_scheduler_policy("performance".to_string())
+        //     .await?;
 
         Ok(Self {
             store,


### PR DESCRIPTION
The hypercall to set the power management policies fail under L1 hypervisor.  Need to lab on EC2 to figure out why.