### PR TITLE
fix(runtime): use iommu only if devices are needed

### DIFF
--- a/crates/runtime/src/launch.rs
+++ b/crates/runtime/src/launch.rs
@@ -229,7 +229,7 @@ impl GuestLauncher {
                 cmdline,
                 uuid,
                 owner_domid: 0,
-                enable_iommu: true,
+                enable_iommu: !request.pcis.is_empty(),
             },
             backend_domid: 0,
             name: xen_name,


### PR DESCRIPTION
PCI devices in the request should indicate use of IOMMU, otherwise disable use of it.