### PR TITLE
chore(dependabot): rename version groups to be more concise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
   schedule:
     interval: "daily"
   groups:
-    production-version-updates:
+    dep-updates:
       dependency-type: "production"
       applies-to: "version-updates"
-    development-version-updates:
+    dev-updates:
       dependency-type: "development"
       applies-to: "version-updates"
 - package-ecosystem: "cargo"
@@ -16,10 +16,10 @@ updates:
   schedule:
     interval: "daily"
   groups:
-    production-version-updates:
+    dep-updates:
       dependency-type: "production"
       applies-to: "version-updates"
-    development-version-updates:
+    dev-updates:
       dependency-type: "development"
       applies-to: "version-updates"
 - package-ecosystem: "docker"
@@ -27,9 +27,9 @@ updates:
   schedule:
     interval: "daily"
   groups:
-    production-version-updates:
+    dep-updates:
       dependency-type: "production"
       applies-to: "version-updates"
-    development-version-updates:
+    dev-updates:
       dependency-type: "development"
       applies-to: "version-updates"


### PR DESCRIPTION
The old group names were long and clogged up the PR names.