### PR TITLE
chore(workflows): use rustup directly to not depend on external actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,9 +17,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        components: rustfmt
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+        rustup component add rustfmt
     - run: ./hack/ci/install-linux-deps.sh
     # Temporarily ignored: https://github.com/edera-dev/krata/issues/206
     - run: ./hack/build/cargo.sh fmt --all -- --check || true

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -35,11 +35,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      if: ${{ matrix.platform.os != 'darwin' }}
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        targets: "${{ matrix.platform.arch }}-apple-darwin"
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+    - run: "rustup target add --toolchain stable ${{ matrix.platform.arch }}-apple-darwin"
       if: ${{ matrix.platform.os == 'darwin' }}
     - uses: homebrew/actions/setup-homebrew@4b34604e75af8f8b23b454f0b5ffb7c5d8ce0056 # master
       if: ${{ matrix.platform.os == 'darwin' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,9 +24,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        targets: "${{ matrix.arch }}-unknown-linux-gnu,${{ matrix.arch }}-unknown-linux-musl"
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+        rustup target add ${{ matrix.arch }}-unknown-linux-gnu ${{ matrix.arch }}-unknown-linux-musl
     - run: ./hack/ci/install-linux-deps.sh
     - run: ./hack/dist/bundle.sh
     - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
@@ -82,11 +83,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      if: ${{ matrix.platform.os != 'darwin' }}
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        targets: "${{ matrix.platform.arch }}-apple-darwin"
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+    - run: "rustup target add --toolchain stable ${{ matrix.platform.arch }}-apple-darwin"
       if: ${{ matrix.platform.os == 'darwin' }}
     - uses: homebrew/actions/setup-homebrew@4b34604e75af8f8b23b454f0b5ffb7c5d8ce0056 # master
       if: ${{ matrix.platform.os == 'darwin' }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -31,9 +31,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        targets: "${{ matrix.arch }}-unknown-linux-gnu,${{ matrix.arch }}-unknown-linux-musl"
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+        rustup target add ${{ matrix.arch }}-unknown-linux-gnu ${{ matrix.arch }}-unknown-linux-musl
     - run: ./hack/ci/install-linux-deps.sh
     - run: ./hack/dist/bundle.sh
     - run: "./hack/ci/assemble-release-assets.sh bundle-systemd ${{ github.event.release.tag_name }} ${{ matrix.arch }} target/dist/bundle-systemd-${{ matrix.arch }}.tgz"
@@ -73,11 +74,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      if: ${{ matrix.platform.os != 'darwin' }}
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: "${{ matrix.platform.arch }}-apple-darwin"
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+    - run: "rustup target add --toolchain stable ${{ matrix.platform.arch }}-apple-darwin"
       if: ${{ matrix.platform.os == 'darwin' }}
     - uses: homebrew/actions/setup-homebrew@4b34604e75af8f8b23b454f0b5ffb7c5d8ce0056 # master
       if: ${{ matrix.platform.os == 'darwin' }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,7 +27,9 @@ jobs:
         submodules: recursive
         fetch-depth: 0
         token: "${{ steps.generate-token.outputs.token }}"
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
     - run: ./hack/ci/install-linux-deps.sh
     - name: release-plz
       uses: MarcoIeni/release-plz-action@86afd21a7b114234aab55ba0005eed52f77d89e4 # v0.5.62

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,7 +25,9 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
     - run: ./hack/ci/install-linux-deps.sh
     - run: ./hack/build/cargo.sh build
   test:
@@ -45,7 +47,9 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
     - run: ./hack/ci/install-linux-deps.sh
     - run: ./hack/build/cargo.sh test
   clippy:
@@ -65,9 +69,10 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        components: clippy
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+        rustup component add clippy
     - run: ./hack/ci/install-linux-deps.sh
     - run: ./hack/build/cargo.sh clippy
   initrd:
@@ -87,8 +92,9 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2 # stable
-      with:
-        targets: "${{ matrix.arch }}-unknown-linux-gnu,${{ matrix.arch }}-unknown-linux-musl"
+    - run: |
+        rustup update --no-self-update stable
+        rustup default stable
+        rustup target add ${{ matrix.arch }}-unknown-linux-gnu ${{ matrix.arch }}-unknown-linux-musl
     - run: ./hack/ci/install-linux-deps.sh
     - run: ./hack/initrd/build.sh


### PR DESCRIPTION
All Rust GitHub actions have dubious security and practices. Use the built-in rustup instead to avoid these pitfalls.