### PR TITLE
chore(dependabot): look for dockerfiles in images subdirectory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       dependency-type: "development"
       applies-to: "version-updates"
 - package-ecosystem: "docker"
-  directory: "/"
+  directory: "/images"
   schedule:
     interval: "daily"
   groups:


### PR DESCRIPTION
This is probably why dependabot can't find anything.