### PR TITLE
fix(workflows): use full platform name in all names

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,7 +136,7 @@ jobs:
         - aarch64
     env:
       TARGET_ARCH: "${{ matrix.arch }}"
-    name: zone initrd ${{ matrix.arch }}
+    name: zone initrd linux-${{ matrix.arch }}
     steps:
     - name: harden runner
       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       TARGET_ARCH: "${{ matrix.arch }}"
       CI_NEEDS_FPM: "1"
-    name: nightly full build ${{ matrix.arch }}
+    name: nightly full build linux-${{ matrix.arch }}
     steps:
     - name: harden runner
       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1


### PR DESCRIPTION
Workflows should contain the full platform name.