### PR TITLE
zone: init: mount /proc with hidepid=1

### DIFF
--- a/crates/zone/src/init.rs
+++ b/crates/zone/src/init.rs
@@ -147,7 +147,7 @@ impl ZoneInit {
         self.create_dir("/run", Some(0o0755)).await?;
         self.mount_kernel_fs("devtmpfs", "/dev", "mode=0755", None, None)
             .await?;
-        self.mount_kernel_fs("proc", "/proc", "", None, None)
+        self.mount_kernel_fs("proc", "/proc", "hidepid=1", None, None)
             .await?;
         self.mount_kernel_fs("sysfs", "/sys", "", None, None)
             .await?;


### PR DESCRIPTION
Mounting procfs with hidepid=1 denies access to procfs directories for processes not accessible by the current user credentials.