### PR TITLE
fix(workflows): upgrade rustup on darwin as best-effort fix for homebrew regression

### DIFF
--- a/hack/ci/install-darwin-deps.sh
+++ b/hack/ci/install-darwin-deps.sh
@@ -2,3 +2,4 @@
 set -e
 
 brew install protobuf
+brew upgrade rustup || true


### PR DESCRIPTION
There is a regression in the rustup formula that has caused cascading problems. This is an emergency PR merge to fix this.