### PR TITLE
fix(idm): process all idm messages in the same frame and use childwait exit notification for exec (fixes #290)

### DIFF
--- a/crates/xen/xenstore/src/sys.rs
+++ b/crates/xen/xenstore/src/sys.rs
@@ -143,19 +143,6 @@ pub const XSD_ERROR_EPERM: XsdError = XsdError {
 pub const XSD_WATCH_PATH: u32 = 0;
 pub const XSD_WATCH_TOKEN: u32 = 1;
 
-#[repr(C)]
-pub struct XenDomainInterface {
-    req: [i8; 1024],
-    rsp: [i8; 1024],
-    req_cons: u32,
-    req_prod: u32,
-    rsp_cons: u32,
-    rsp_prod: u32,
-    server_features: u32,
-    connection: u32,
-    error: u32,
-}
-
 pub const XS_PAYLOAD_MAX: u32 = 4096;
 pub const XS_ABS_PATH_MAX: u32 = 3072;
 pub const XS_REL_PATH_MAX: u32 = 2048;


### PR DESCRIPTION
The IDM decoder for the daemon was discarding packets that were in the same frame as the packet. This adds a loop to fix that bug, ensuring that packets are processed in the buffer as available. In addition, exec has been modified to use the child wait mechanism for exit notifications, preventing the flakiness of the exec. With this change, exec ran in a tight loop for 1 minute. It would barely make it 10 iterations prior to this change.