### PR TITLE
fix(power-trap-eacces): gracefully handle hypercall errors in power management

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -141,12 +141,12 @@ impl Daemon {
 
         // TODO: Create a way of abstracting early init tasks in kratad.
         // TODO: Make initial power management policy configurable.
-        // FIXME: Power management hypercalls fail when running as an L1 hypervisor.
-        // let power = runtime.power_management_context().await?;
-        // power.set_smt_policy(true).await?;
-        // power
-        //     .set_scheduler_policy("performance".to_string())
-        //     .await?;
+        let power = runtime.power_management_context().await?;
+        power.set_smt_policy(true).await?;
+        power
+            .set_scheduler_policy("performance".to_string())
+            .await?;
+        info!("power management initialized");
 
         info!("krata daemon initialized");
         Ok(Self {

--- a/crates/runtime/src/power.rs
+++ b/crates/runtime/src/power.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use indexmap::IndexMap;
+use log::info;
 use xencall::sys::{CpuId, SysctlCputopo};
 
 use crate::RuntimeContext;
@@ -151,7 +152,10 @@ impl PowerManagementContext {
             .xen
             .call
             .set_turbo_mode(CpuId::All, enable)
-            .await?;
+            .await
+            .unwrap_or_else(|error| {
+                info!("non-fatal error while setting SMT policy: {:?}", error);
+            });
         Ok(())
     }
 
@@ -161,7 +165,10 @@ impl PowerManagementContext {
             .xen
             .call
             .set_cpufreq_gov(CpuId::All, policy)
-            .await?;
+            .await
+            .unwrap_or_else(|error| {
+                info!("non-fatal error while setting scheduler policy: {:?}", error);
+            });
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #293 in that it removes the hang.  We are still figuring out why the EACCES is happening.