### PR TITLE
Add support for reading hypervisor console

### DIFF
--- a/crates/ctl/src/cli/host/dmesg.rs
+++ b/crates/ctl/src/cli/host/dmesg.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use clap::Parser;
+use krata::v1::control::{
+    control_service_client::ControlServiceClient, ReadHypervisorConsoleRingRequest,
+};
+
+use tonic::{transport::Channel, Request};
+
+#[derive(Parser)]
+#[command(about = "Display hypervisor diagnostic messages")]
+pub struct HostHypervisorMessagesCommand {
+}
+
+impl HostHypervisorMessagesCommand {
+    pub async fn run(self, mut client: ControlServiceClient<Channel>) -> Result<()> {
+        let response = client
+            .read_hypervisor_console_ring(Request::new(ReadHypervisorConsoleRingRequest { clear: false }))
+            .await?
+            .into_inner();
+
+        print!("{}", response.data);
+        Ok(())
+    }
+}

--- a/crates/ctl/src/cli/host/hv_console.rs
+++ b/crates/ctl/src/cli/host/hv_console.rs
@@ -8,10 +8,10 @@ use tonic::{transport::Channel, Request};
 
 #[derive(Parser)]
 #[command(about = "Display hypervisor diagnostic messages")]
-pub struct HostHypervisorMessagesCommand {
+pub struct HostHvConsoleCommand {
 }
 
-impl HostHypervisorMessagesCommand {
+impl HostHvConsoleCommand {
     pub async fn run(self, mut client: ControlServiceClient<Channel>) -> Result<()> {
         let response = client
             .read_hypervisor_console_ring(Request::new(ReadHypervisorConsoleRingRequest { clear: false }))

--- a/crates/ctl/src/cli/host/hv_console.rs
+++ b/crates/ctl/src/cli/host/hv_console.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use krata::v1::control::{
-    control_service_client::ControlServiceClient, ReadHypervisorConsoleRingRequest,
+    control_service_client::ControlServiceClient, ReadHypervisorConsoleRequest,
 };
 
 use tonic::{transport::Channel, Request};
@@ -14,7 +14,7 @@ pub struct HostHvConsoleCommand {
 impl HostHvConsoleCommand {
     pub async fn run(self, mut client: ControlServiceClient<Channel>) -> Result<()> {
         let response = client
-            .read_hypervisor_console_ring(Request::new(ReadHypervisorConsoleRingRequest { clear: false }))
+            .read_hypervisor_console(Request::new(ReadHypervisorConsoleRequest {}))
             .await?
             .into_inner();
 

--- a/crates/ctl/src/cli/host/mod.rs
+++ b/crates/ctl/src/cli/host/mod.rs
@@ -8,10 +8,12 @@ use krata::v1::control::control_service_client::ControlServiceClient;
 use crate::cli::host::cpu_topology::HostCpuTopologyCommand;
 use crate::cli::host::identify::HostStatusCommand;
 use crate::cli::host::idm_snoop::HostIdmSnoopCommand;
+use crate::cli::host::dmesg::HostHypervisorMessagesCommand;
 
 pub mod cpu_topology;
 pub mod identify;
 pub mod idm_snoop;
+pub mod dmesg;
 
 #[derive(Parser)]
 #[command(about = "Manage the host of the isolation engine")]
@@ -35,6 +37,7 @@ pub enum HostCommands {
     CpuTopology(HostCpuTopologyCommand),
     Status(HostStatusCommand),
     IdmSnoop(HostIdmSnoopCommand),
+    HypervisorMessages(HostHypervisorMessagesCommand),
 }
 
 impl HostCommands {
@@ -49,6 +52,8 @@ impl HostCommands {
             HostCommands::Status(status) => status.run(client).await,
 
             HostCommands::IdmSnoop(snoop) => snoop.run(client, events).await,
+
+            HostCommands::HypervisorMessages(hvdmesg) => hvdmesg.run(client).await,
         }
     }
 }

--- a/crates/ctl/src/cli/host/mod.rs
+++ b/crates/ctl/src/cli/host/mod.rs
@@ -8,12 +8,12 @@ use krata::v1::control::control_service_client::ControlServiceClient;
 use crate::cli::host::cpu_topology::HostCpuTopologyCommand;
 use crate::cli::host::identify::HostStatusCommand;
 use crate::cli::host::idm_snoop::HostIdmSnoopCommand;
-use crate::cli::host::dmesg::HostHypervisorMessagesCommand;
+use crate::cli::host::hv_console::HostHvConsoleCommand;
 
 pub mod cpu_topology;
 pub mod identify;
 pub mod idm_snoop;
-pub mod dmesg;
+pub mod hv_console;
 
 #[derive(Parser)]
 #[command(about = "Manage the host of the isolation engine")]
@@ -37,7 +37,7 @@ pub enum HostCommands {
     CpuTopology(HostCpuTopologyCommand),
     Status(HostStatusCommand),
     IdmSnoop(HostIdmSnoopCommand),
-    HypervisorMessages(HostHypervisorMessagesCommand),
+    HvConsole(HostHvConsoleCommand),
 }
 
 impl HostCommands {
@@ -53,7 +53,7 @@ impl HostCommands {
 
             HostCommands::IdmSnoop(snoop) => snoop.run(client, events).await,
 
-            HostCommands::HypervisorMessages(hvdmesg) => hvdmesg.run(client).await,
+            HostCommands::HvConsole(hvconsole) => hvconsole.run(client).await,
         }
     }
 }

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -28,6 +28,7 @@ use krata::{
             ReadZoneMetricsReply, ReadZoneMetricsRequest, ResolveZoneIdReply, ResolveZoneIdRequest,
             SnoopIdmReply, SnoopIdmRequest, UpdateZoneResourcesReply, UpdateZoneResourcesRequest,
             WatchEventsReply, WatchEventsRequest, ZoneConsoleReply, ZoneConsoleRequest,
+            ReadHypervisorConsoleRingRequest, ReadHypervisorConsoleRingReply,
         },
     },
 };
@@ -709,5 +710,16 @@ impl ControlService for DaemonControlService {
             .await
             .map_err(ApiError::from)?;
         Ok(Response::new(UpdateZoneResourcesReply {}))
+    }
+
+    async fn read_hypervisor_console_ring(
+        &self,
+        request: Request<ReadHypervisorConsoleRingRequest>,
+    ) -> Result<Response<ReadHypervisorConsoleRingReply>, Status> {
+        let request = request.into_inner();
+        let data = self.runtime.read_hypervisor_console(request.clear).await.map_err(|error| ApiError {
+            message: error.to_string(),
+        })?;
+        Ok(Response::new(ReadHypervisorConsoleRingReply { data: data.to_string() }))
     }
 }

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -28,7 +28,7 @@ use krata::{
             ReadZoneMetricsReply, ReadZoneMetricsRequest, ResolveZoneIdReply, ResolveZoneIdRequest,
             SnoopIdmReply, SnoopIdmRequest, UpdateZoneResourcesReply, UpdateZoneResourcesRequest,
             WatchEventsReply, WatchEventsRequest, ZoneConsoleReply, ZoneConsoleRequest,
-            ReadHypervisorConsoleRingRequest, ReadHypervisorConsoleRingReply,
+            ReadHypervisorConsoleRequest, ReadHypervisorConsoleReply,
         },
     },
 };
@@ -712,14 +712,13 @@ impl ControlService for DaemonControlService {
         Ok(Response::new(UpdateZoneResourcesReply {}))
     }
 
-    async fn read_hypervisor_console_ring(
+    async fn read_hypervisor_console(
         &self,
-        request: Request<ReadHypervisorConsoleRingRequest>,
-    ) -> Result<Response<ReadHypervisorConsoleRingReply>, Status> {
-        let request = request.into_inner();
-        let data = self.runtime.read_hypervisor_console(request.clear).await.map_err(|error| ApiError {
+        _request: Request<ReadHypervisorConsoleRequest>,
+    ) -> Result<Response<ReadHypervisorConsoleReply>, Status> {
+        let data = self.runtime.read_hypervisor_console(false).await.map_err(|error| ApiError {
             message: error.to_string(),
         })?;
-        Ok(Response::new(ReadHypervisorConsoleRingReply { data: data.to_string() }))
+        Ok(Response::new(ReadHypervisorConsoleReply { data: data.to_string() }))
     }
 }

--- a/crates/krata/proto/krata/v1/control.proto
+++ b/crates/krata/proto/krata/v1/control.proto
@@ -36,7 +36,7 @@ service ControlService {
 
     rpc WatchEvents(WatchEventsRequest) returns (stream WatchEventsReply);
 
-    rpc ReadHypervisorConsoleRing(ReadHypervisorConsoleRingRequest) returns (ReadHypervisorConsoleRingReply);
+    rpc ReadHypervisorConsole(ReadHypervisorConsoleRequest) returns (ReadHypervisorConsoleReply);
 }
 
 message HostStatusRequest {}
@@ -255,10 +255,8 @@ message UpdateZoneResourcesRequest {
 
 message UpdateZoneResourcesReply {}
 
-message ReadHypervisorConsoleRingRequest {
-    bool clear = 1;
-}
+message ReadHypervisorConsoleRequest {}
 
-message ReadHypervisorConsoleRingReply {
+message ReadHypervisorConsoleReply {
     string data = 1;
 }

--- a/crates/krata/proto/krata/v1/control.proto
+++ b/crates/krata/proto/krata/v1/control.proto
@@ -35,6 +35,8 @@ service ControlService {
     rpc ReadZoneMetrics(ReadZoneMetricsRequest) returns (ReadZoneMetricsReply);
 
     rpc WatchEvents(WatchEventsRequest) returns (stream WatchEventsReply);
+
+    rpc ReadHypervisorConsoleRing(ReadHypervisorConsoleRingRequest) returns (ReadHypervisorConsoleRingReply);
 }
 
 message HostStatusRequest {}
@@ -252,3 +254,11 @@ message UpdateZoneResourcesRequest {
 }
 
 message UpdateZoneResourcesReply {}
+
+message ReadHypervisorConsoleRingRequest {
+    bool clear = 1;
+}
+
+message ReadHypervisorConsoleRingReply {
+    string data = 1;
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -297,4 +297,14 @@ impl Runtime {
         let context = RuntimeContext::new().await?;
         Ok(PowerManagementContext { context })
     }
+
+    pub async fn read_hypervisor_console(&self, clear: bool) -> Result<Arc<str>> {
+        let index = 0 as u32;
+        let (rawbuf, newindex) = self.context
+                                     .xen
+                                     .call
+                                     .read_console_ring_raw(clear, index).await?;
+        let buf = std::str::from_utf8(&rawbuf[..newindex as usize])?;
+        Ok(Arc::from(buf))
+    }
 }

--- a/crates/xen/xencall/examples/console_read.rs
+++ b/crates/xen/xencall/examples/console_read.rs
@@ -1,0 +1,18 @@
+use xencall::error::Result;
+use xencall::XenCall;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+
+    let call = XenCall::open(0)?;
+    let index = 0 as u32;
+    let (buf, newindex) = call.read_console_ring_raw(false, index).await?;
+
+    match std::str::from_utf8(&buf[..newindex as usize]) {
+        Ok(v) => print!("{}", v),
+        _ => panic!("unable to decode Xen console messages"),
+    };
+
+    Ok(())
+}

--- a/crates/xen/xencall/src/sys.rs
+++ b/crates/xen/xencall/src/sys.rs
@@ -752,6 +752,7 @@ pub struct SysctlCputopoinfo {
 
 #[repr(C)]
 pub union SysctlValue {
+    pub console: SysctlReadconsole,
     pub cputopoinfo: SysctlCputopoinfo,
     pub pm_op: SysctlPmOp,
     pub phys_info: SysctlPhysinfo,
@@ -765,6 +766,7 @@ pub struct Sysctl {
     pub value: SysctlValue,
 }
 
+pub const XEN_SYSCTL_READCONSOLE: u32 = 1;
 pub const XEN_SYSCTL_PHYSINFO: u32 = 3;
 pub const XEN_SYSCTL_PM_OP: u32 = 12;
 pub const XEN_SYSCTL_CPUTOPOINFO: u32 = 16;
@@ -801,4 +803,15 @@ pub struct SysctlPhysinfo {
     pub outstanding_pages: u64,
     pub max_mfn: u64,
     pub hw_cap: [u32; 8],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SysctlReadconsole {
+    pub clear: u8,
+    pub incremental: u8,
+    pub pad: u16,
+    pub index: u32,
+    pub buffer: u64,
+    pub count: u32,
 }


### PR DESCRIPTION
Adds `kratactl host hv-console` to read the hypervisor console which contains diagnostic messages.

Closes #328.