### PR TITLE
fix(network): allocate host ip from allocation pool

### DIFF
--- a/crates/ctl/src/cli/host/identify.rs
+++ b/crates/ctl/src/cli/host/identify.rs
@@ -17,6 +17,9 @@ impl HostStatusCommand {
         println!("Host UUID: {}", response.host_uuid);
         println!("Host Domain: {}", response.host_domid);
         println!("Krata Version: {}", response.krata_version);
+        println!("Host IPv4: {}", response.host_ipv4);
+        println!("Host IPv6: {}", response.host_ipv6);
+        println!("Host Ethernet Address: {}", response.host_mac);
         Ok(())
     }
 }

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -97,7 +97,7 @@ fn default_network_ipv4() -> DaemonIpv4NetworkConfig {
 }
 
 fn default_network_ipv4_subnet() -> String {
-    "10.75.80.0/24".to_string()
+    "10.75.0.0/16".to_string()
 }
 
 fn default_network_ipv6() -> DaemonIpv6NetworkConfig {

--- a/crates/daemon/src/reconcile/zone/mod.rs
+++ b/crates/daemon/src/reconcile/zone/mod.rs
@@ -380,9 +380,9 @@ pub fn ip_reservation_to_network_status(ip: &IpReservation) -> ZoneNetworkStatus
     ZoneNetworkStatus {
         zone_ipv4: format!("{}/{}", ip.ipv4, ip.ipv4_prefix),
         zone_ipv6: format!("{}/{}", ip.ipv6, ip.ipv6_prefix),
-        zone_mac: ip.mac.to_string().replace('-', ":"),
+        zone_mac: ip.mac.to_string().to_lowercase().replace('-', ":"),
         gateway_ipv4: format!("{}/{}", ip.gateway_ipv4, ip.ipv4_prefix),
         gateway_ipv6: format!("{}/{}", ip.gateway_ipv6, ip.ipv6_prefix),
-        gateway_mac: ip.gateway_mac.to_string().replace('-', ":"),
+        gateway_mac: ip.gateway_mac.to_string().to_lowercase().replace('-', ":"),
     }
 }

--- a/crates/krata/proto/krata/v1/control.proto
+++ b/crates/krata/proto/krata/v1/control.proto
@@ -45,6 +45,9 @@ message HostStatusReply {
     string host_uuid = 1;
     uint32 host_domid = 2;
     string krata_version = 3;
+    string host_ipv4 = 4;
+    string host_ipv6 = 5;
+    string host_mac = 6;
 }
 
 message CreateZoneRequest {

--- a/crates/network/src/backend.rs
+++ b/crates/network/src/backend.rs
@@ -127,7 +127,8 @@ impl NetworkBackend {
         let (tx_sender, tx_receiver) = channel::<BytesMut>(TX_CHANNEL_BUFFER_LEN);
         let mut udev = ChannelDevice::new(mtu, Medium::Ethernet, tx_sender.clone());
         let mac = self.metadata.gateway.mac;
-        let nat = Nat::new(mtu, proxy, mac, addresses.clone(), tx_sender.clone())?;
+        let local_cidrs = addresses.clone();
+        let nat = Nat::new(mtu, proxy, mac, local_cidrs, tx_sender.clone())?;
         let hardware_addr = HardwareAddress::Ethernet(mac);
         let config = Config::new(hardware_addr);
         let mut iface = Interface::new(config, &mut udev, Instant::now());


### PR DESCRIPTION
This implements allocation of the host IP from the reservation store. The gateway IP is now allocated using an all zero UUID, since it is a fake IP.