### PR TITLE
fix(xenevtchn): correct ioctl numbers

### DIFF
--- a/crates/xen/xenevtchn/src/sys.rs
+++ b/crates/xen/xenevtchn/src/sys.rs
@@ -1,4 +1,4 @@
-use nix::{ioctl_none, ioctl_readwrite_bad};
+use nix::{ioctl_none_bad, ioctl_readwrite_bad};
 use std::ffi::c_uint;
 
 #[repr(C)]
@@ -29,7 +29,7 @@ pub struct NotifyRequest {
 
 ioctl_readwrite_bad!(bind_virq, 0x44500, BindVirqRequest);
 ioctl_readwrite_bad!(bind_interdomain, 0x84501, BindInterdomainRequest);
-ioctl_readwrite_bad!(bind_unbound_port, 0x44503, BindUnboundPortRequest);
-ioctl_readwrite_bad!(unbind, 0x44502, UnbindPortRequest);
+ioctl_readwrite_bad!(bind_unbound_port, 0x44502, BindUnboundPortRequest);
+ioctl_readwrite_bad!(unbind, 0x44503, UnbindPortRequest);
 ioctl_readwrite_bad!(notify, 0x44504, NotifyRequest);
-ioctl_none!(reset, 0x4505, 5);
+ioctl_none_bad!(reset, 0x4505);


### PR DESCRIPTION
I have been trying krata with some things, and I think I found three bugs in `crates/xen/xenevtchn/src/sys.rs`, verified against `linux/xen/evtchn.h`. If these are irrelevant, please close.

**Issues**

**1. `bind_unbound_port` and `unbind` ioctl numbers are swapped**

Kernel header:
```c
#define IOCTL_EVTCHN_BIND_UNBOUND_PORT  _IOC(_IOC_NONE, 'E', 2, sizeof(...))  // nr=2
#define IOCTL_EVTCHN_UNBIND             _IOC(_IOC_NONE, 'E', 3, sizeof(...))  // nr=3
```

Code had `bind_unbound_port` at nr=3 (`0x44503`) and `unbind` at nr=2 (`0x44502`). Fixed.

**2. `reset` ioctl truncated by nix TYPEMASK**

`ioctl_none!(reset, 0x4505, 5)` -- nix's `ioctl_none!` applies `TYPEMASK` (`0xFF`) to the type arg:
- `0x4505 & 0xFF = 0x05`
- Produces `0x0505` instead of `0x4505`

Fixed by switching to `ioctl_none_bad!` which passes the raw value.

**Verification**

- Checked against `linux/xen/evtchn.h` (kernel 6.19.3, Xen 4.21)
- Tested with Python `fcntl.ioctl()` on live Xen hardware